### PR TITLE
Haskell: using haskell platform 7.10

### DIFF
--- a/config/lang-haskell.yml
+++ b/config/lang-haskell.yml
@@ -1,6 +1,6 @@
 name: haskell
 visible_name: Haskell (GHC + Haskell Platform)
-version: "7.6.3"
+version: "7.10.2"
 compiler_profile: straitjacket/compiler/ghc
 apparmor_profile: straitjacket/compiled/ghc
 filename: source.hs

--- a/files/etc/apparmor.d/straitjacket.compiler.ghc
+++ b/files/etc/apparmor.d/straitjacket.compiler.ghc
@@ -9,13 +9,12 @@ profile straitjacket/compiler/ghc {
   /tmp/** rw,
 
   /bin/dash rix,
-  /usr/bin/ghc rix,
+  /usr/local/bin/ghc rix,
 
-  /usr/lib/ghc{-*,}/**.o mr,
-  /usr/lib/ghc{-*,}/bin/ghc-* rix,
-  /usr/lib/ghc{-*,}/lib/ghc rix,
-  /usr/lib/ghc{-*,}/lib/runghc rix,
-  /usr/lib/*/gconf/UTF-*.so mr,
-  /var/lib/ghc{-*,}/package.conf.d/package.cache r,
+  /usr/local/haskell/ghc{-*,}/**.o mr,
+  /usr/local/haskell/ghc{-*,}/bin/ghc-* rix,
+  /usr/local/haskell/ghc{-*,}/lib/** rix,
+  /usr/local/haskell/*/gconf/UTF-*.so mr,
+  /var/local/haskell/ghc{-*,}/package.conf.d/package.cache r,
 
 }

--- a/languages/haskell/Dockerfile
+++ b/languages/haskell/Dockerfile
@@ -1,8 +1,12 @@
 FROM buildpack-deps:jessie
 
 RUN         apt-get update && \
-            apt-get install -y haskell-platform && \
+            apt-get install -y ca-certificates libtinfo-dev ca-certificates g++ libgmp10 libgmp-dev libffi-dev zlib1g-dev && \
             apt-get clean && \
+            cd /tmp && \
+            wget -nv https://haskell.org/platform/download/7.10.2/haskell-platform-7.10.2-a-unknown-linux-deb7.tar.gz && \
+            tar xf haskell-platform-7.10.2-a-unknown-linux-deb7.tar.gz && \
+            ./install-haskell-platform.sh && \
             rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD build-run /build-run


### PR DESCRIPTION
I used the generic linux download from here: https://www.haskell.org/platform/#linux-generic

Then I installed dependencies as recommended by the following: 

* https://github.com/freebroccolo/docker-haskell/blob/master/7.10/Dockerfile
* http://www.extellisys.com/articles/haskell-on-debian-wheezy

I did these commands by hand and successfully tested ghc, using both Data.Vector and Data.HashMap. I may be missing something, but when I went to test the docker image, it fails with an error. 

    $ docker build -t mebi-haskell .
    $ docker run -it mebi-haskell /bin/bash
    /build-run: line 8: /src/main: No such file or directory

Is that expected? I've never used the ENTRYPOINT command before and it looks like it's not letting me decide what to run. 