### PR TITLE
haskell: added optimization flag

### DIFF
--- a/languages/haskell/build-run
+++ b/languages/haskell/build-run
@@ -3,7 +3,7 @@
 set -e
 
 if [ "$1" == "--build" ]; then
-  ghc -o /src/main $2
+  ghc -O -o /src/main $2
 else
   /src/main
 fi


### PR DESCRIPTION
I added a simple optimization flag to the ghc build step. See here: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/options-optimise.html

It should make a huge difference to runtime speeds. 

I ran tests in vagrant and we're passing. 